### PR TITLE
Separate meta path elements with spaces in strings

### DIFF
--- a/util/datastructures.py
+++ b/util/datastructures.py
@@ -25,4 +25,4 @@ class MetaPath:
         return len(self.edges) + len(self.nodes)
 
     def __str__(self):
-        return ';'.join(map(str, self.as_list()))
+        return ' '.join(map(str, self.as_list()))


### PR DESCRIPTION
Separate meta path elements with spaces in string representation of meta-pats. This makes it easier to deal with the strings in sklearn's text processing classes.