### PR TITLE
Add option to specify port binding of server and ui

### DIFF
--- a/deployment/run-server.sh
+++ b/deployment/run-server.sh
@@ -2,6 +2,6 @@
 docker stop server-container
 docker rm server-container
 docker run --name server-container \
-           --publish=8000:8000 \
+           --publish=${1:-8000}:8000 \
            -d \
            server

--- a/deployment/run-ui.sh
+++ b/deployment/run-ui.sh
@@ -2,6 +2,6 @@
 docker stop ui-container
 docker rm ui-container
 docker run --name ui-container \
-           --publish=80:80 \
+           --publish=${1:-80}:80 \
            -d \
            ui


### PR DESCRIPTION
Allow to specify the port to bind the server or ui docker app to. This for examples fixes issues when port 80 is already used by another process.