### PR TITLE
Set cryptography to working version 2.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ scipy
 # TODO: Introduce development (non-deployment) dependencies
 pytest-cov
 Flask-Session
+cryptography==2.1.4
 flask-ask


### PR DESCRIPTION
Set cryptography to working version 2.1.4 because newest version 2.2 fails to install.