### PR TITLE
Add logging support to our modules

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -17,7 +17,7 @@ ask = Ask(app, '/alexa')
 
 """ 
     Logging guideline:
-    - Use flasks logger in this module. You can accessible via app.logger.
+    - Use flasks logger in this module. You can access it via app.logger.
     - In the other modules use the MetaExp-Logger. For example if you wanted to equip the module Example with a logger, 
       you would simply create a child logger by logging.getLogger('MetaExp.Example'). If you wanted to use a logger for 
       each class, you would define it as self.logger = logging.getLogger('MetaExp.{}'.format(__class__.__name__)).

--- a/api/server.py
+++ b/api/server.py
@@ -1,7 +1,7 @@
 from flask import Flask, jsonify, request, abort, session
 from flask_session import Session
 from flask_cors import CORS
-from util.config import SERVER_PATH, REACT_PORT, API_PORT, SESSION_CACHE_DIR, SESSION_MODE, SESSION_THRESHOLD, RATED_DATASETS_PATH
+from util.config import *
 from util.meta_path_loader_dispatcher import MetaPathLoaderDispatcher
 from util.graph_stats import GraphStats
 from active_learning.active_learner import UncertaintySamplingAlgorithm
@@ -14,6 +14,17 @@ from flask_ask import Ask
 
 app = Flask(__name__)
 ask = Ask(app, '/alexa')
+
+""" 
+    Logging guideline:
+    - Use flasks logger in this module. You can accessible via app.logger.
+    - In the other modules use the MetaExp-Logger. For example if you wanted to equip the module Example with a logger, 
+      you would simply create a child logger by logging.getLogger('MetaExp.Example'). If you wanted to use a logger for 
+      each class, you would define it as self.logger = logging.getLogger('MetaExp.{}'.format(__class__.__name__)).
+      
+    To see the logging messages you have to start flask with the argument debug=True.
+"""
+set_up_logger()
 
 # TODO: Change if we have a database in the background
 SESSION_TYPE = 'filesystem'

--- a/util/config.py
+++ b/util/config.py
@@ -1,10 +1,11 @@
 import os
+from logging.config import dictConfig
 
 # algorithms
 RESEARCH_MODE = "research"
 BASELINE_MODE = "baseline"
 # development
-RANDOM_STATE = 42 # change it to something random if it should not be reconstructive.
+RANDOM_STATE = 42  # change it to something random if it should not be reconstructive.
 # server
 REACT_PORT = 3000
 API_PORT = 8000
@@ -17,3 +18,27 @@ MOCK_DATASETS_DIR = os.path.join('tests', 'data')
 SESSION_CACHE_DIR = os.path.join('tmp', 'sessions')
 SESSION_THRESHOLD = 500
 SESSION_MODE = '0700'
+
+
+def set_up_logger():
+    dictConfig({
+        'version': 1,
+        'formatters': {'default': {
+            'format': '[%(asctime)s] %(levelname)s from %(name)s: %(message)s',
+        }},
+        'handlers': {
+            'default': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'default',
+                'level': 'DEBUG'
+            }},
+        'loggers': {
+            'MetaExp': {
+                'handlers': ['default']
+            }
+        },
+        'root': {
+            'level': 'DEBUG',
+            'handlers': []
+        },
+    })

--- a/util/meta_path_loader.py
+++ b/util/meta_path_loader.py
@@ -5,6 +5,7 @@ import pandas as pd
 from .config import ROTTEN_TOMATO_PATH
 import os
 import io
+import logging
 
 
 class AbstractMetaPathLoader(ABC):
@@ -36,6 +37,9 @@ class AbstractMetaPathLoader(ABC):
 class RottenTomatoMetaPathLoader(AbstractMetaPathLoader):
     dataset_filename = 'rotten-(when_harry_met_sally-sleepless_in_seattle)-mp1-5.csv'
 
+    def __init__(self):
+        self.logger = logging.getLogger('MetaExp.{}'.format(__class__.__name__))
+
     def load_meta_paths(self) -> List[MetaPath]:
         df = pd.read_csv(
             os.path.join(ROTTEN_TOMATO_PATH, self.dataset_filename))
@@ -50,12 +54,14 @@ class RottenTomatoMetaPathLoader(AbstractMetaPathLoader):
             edges = i[1]
             mp = self.string_to_meta_path(nodes, edges)
             meta_paths.append(mp)
-        print("{}: Number of meta-paths is {}".format(self.__class__.__name__.upper(), len(meta_paths)))
+        self.logger.debug("Successfully extracted meta paths from file")
+        self.logger.debug("Number of meta-paths is {}".format(len(meta_paths)))
         return meta_paths
 
 
 class CypherDataSetLoader(AbstractMetaPathLoader):
     def __init__(self, dataset_path):
+        self.logger = logging.getLogger('MetaExp.{}'.format(__class__.__name__))
         self.dataset_path = dataset_path
 
     def load_meta_paths(self) -> List[MetaPath]:
@@ -82,11 +88,13 @@ class CypherDataSetLoader(AbstractMetaPathLoader):
             nodes = [i[0] for i in row.nodes_types]
             edges = [rel_type.split('/')[-1] for rel_type in row.relationship_types]
             meta_paths.append(MetaPath(nodes=nodes, edges=edges))
-        print("{}: Number of meta-paths is {}".format(self.__class__.__name__.upper(), len(meta_paths)))
+        self.logger.debug("Successfully extracted meta paths from file")
+        self.logger.debug("Number of meta-paths is {}.".format(len(meta_paths)))
         return meta_paths
 
 class CypherDataSetLoaderWithoutCounts(AbstractMetaPathLoader):
     def __init__(self, dataset_path):
+        self.logger = logging.getLogger('MetaExp.{}'.format(__class__.__name__))
         self.dataset_path = dataset_path
 
     def load_meta_paths(self) -> List[MetaPath]:
@@ -114,5 +122,6 @@ class CypherDataSetLoaderWithoutCounts(AbstractMetaPathLoader):
             nodes = [i[0] for i in row.nodes_types]
             edges = [rel_type.split('/')[-1] for rel_type in row.relationship_types]
             meta_paths.append(MetaPath(nodes=nodes, edges=edges))
-        print("{}: Number of meta-paths is {}".format(self.__class__.__name__.upper(), len(meta_paths)))
+        self.logger.debug("Successfully extracted meta paths from file")
+        self.logger.debug("Number of meta-paths is {}".format(len(meta_paths)))
         return meta_paths


### PR DESCRIPTION
Proposed logging guideline:

- Use flasks logger in server-module. You can access it via `app.logger`.
 - In the other modules use the MetaExp-Logger. For example if you wanted to equip the module Example with a logger, you would simply create a child logger by `logging.getLogger('MetaExp.Example')`. If you wanted to use a logger for each class, you would define it as `self.logger = logging.getLogger('MetaExp.{}'.format(__class__.__name__))`.