### PR TITLE
Backend support for new rating page

### DIFF
--- a/active_learning/evaluation.py
+++ b/active_learning/evaluation.py
@@ -43,7 +43,7 @@ class Evaluator:
 
         while self.oracle._wants_to_continue() == True and not is_last_batch:
             # Retrieve next batch
-            next_metapaths, is_last_batch = self.algorithm.get_next(batch_size=self.batch_size)
+            next_metapaths, is_last_batch, ref_paths = self.algorithm.get_next(batch_size=self.batch_size)
             ids_to_be_rated = [mp['id'] for mp in next_metapaths]
             logger.info("\tRating paths:\t{}".format(ids_to_be_rated))
 

--- a/active_learning/hypothesis.py
+++ b/active_learning/hypothesis.py
@@ -43,9 +43,9 @@ class GaussianProcessHypothesis:
     def __init__(self, meta_paths, **hypothesis_params):
         self.logger = logging.getLogger('MetaExp.{}'.format(__class__.__name__))
         kernel = 1.0 * RBF(length_scale=1.0, length_scale_bounds=(1e-1, 10.0))
-        self.gp = GaussianProcessRegressor(kernel=kernel, optimizer=None)
+        self.gp = GaussianProcessRegressor(kernel=kernel,optimizer=None)
         if not 'embedding_strategy' in hypothesis_params:
-            self.meta_paths = self._length_based_transform(meta_paths)
+            self.meta_paths = self._tfidf_transform(meta_paths)
         else:
             self.meta_paths = hypothesis_params['embedding_strategy'](meta_paths)
 


### PR DESCRIPTION
Our new rating page concept is now supported by our backend. The so far most 'extreme' rated meta paths will be delivered to the frontend from the second batch on. These are used as reference points for the user. They are able to move and rearrange the reference points in correspondence to the batch they are currently reviewing. By that the user is able to extent the absolute scale of meta-path relevance unknowingly. The backend then performs the transformation. See `transform rating` in server module.